### PR TITLE
Fixed StrictFintoTermSelection to use newer DefaultSelection

### DIFF
--- a/src/Plugin/EntityReferenceSelection/StrictFintoTermSelection.php
+++ b/src/Plugin/EntityReferenceSelection/StrictFintoTermSelection.php
@@ -2,10 +2,14 @@
 
 namespace Drupal\finto_taxonomy\Plugin\EntityReferenceSelection;
 
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\taxonomy\Plugin\EntityReferenceSelection\TermSelection;
+
 
 /**
  * This custom selection allows for restricting autocomplete to Finto terms.
@@ -23,9 +27,11 @@ use Drupal\taxonomy\Plugin\EntityReferenceSelection\TermSelection;
  * )
  */
 class StrictFintoTermSelection extends TermSelection {
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityManagerInterface $entity_manager, ModuleHandlerInterface $module_handler, AccountInterface $current_user) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, AccountInterface $current_user, EntityFieldManagerInterface $entity_field_manager = NULL, EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, EntityRepositoryInterface $entity_repository = NULL) {
     // Vocabulary always forced to 'finto'.
+    
     $configuration['target_bundles'] = ['finto' => 'finto'];
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_manager, $module_handler, $current_user);
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $module_handler, $current_user, $entity_field_manager, $entity_type_bundle_info, $entity_repository);
   }
+
 }


### PR DESCRIPTION
This pull requests targets this issue: https://projektit.kirjastot.fi/issues/5674

Commit:

Not 100% sure which Drupal update modified the DefaultSelection class in a way that it
broke our module. For comparison here is the same constructor from Drupal 8.2 vs Drupal 8.7

Drupal 8.2:
public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityManagerInterface $entity_manager, ModuleHandlerInterface $module_handler, AccountInterface $current_user) {

Drupal 8.7:
public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, AccountInterface $current_user, EntityFieldManagerInterface $entity_field_manager = NULL, EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, EntityRepositoryInterface $entity_repository = NULL) {